### PR TITLE
Use Swift to set attributes for seckey

### DIFF
--- a/compile-ios.sh
+++ b/compile-ios.sh
@@ -1,0 +1,23 @@
+
+cd prebuilt
+
+xcodebuild build -scheme Attributes -configuration Release -arch arm64 -sdk 'iphoneos' \
+  BUILD_LIBRARY_FOR_DISTRIBUTION=YES \
+  -derivedDataPath './Attributes/build/' \
+  -project Attributes/Attributes.xcodeproj
+cp Attributes/build/Build/Products/Release-iphoneos/libAttributes.a Attributes/binaries/arm64
+rm -rf Attributes/build
+
+xcodebuild build -scheme Attributes -configuration Release -arch arm64 -sdk 'iphonesimulator' \
+  BUILD_LIBRARY_FOR_DISTRIBUTION=YES \
+  -derivedDataPath './Attributes/build/' \
+  -project Attributes/Attributes.xcodeproj
+cp Attributes/build/Build/Products/Release-iphonesimulator/libAttributes.a Attributes/binaries/arm64-simulator
+rm -rf Attributes/build
+
+xcodebuild build -scheme Attributes -configuration Release -arch x86_64 -sdk 'iphonesimulator' \
+  BUILD_LIBRARY_FOR_DISTRIBUTION=YES \
+  -derivedDataPath './Attributes/build/' \
+  -project Attributes/Attributes.xcodeproj
+cp Attributes/build/Build/Products/Release-iphonesimulator/libAttributes.a Attributes/binaries/x64
+rm -rf Attributes/build

--- a/encryption/build.gradle.kts
+++ b/encryption/build.gradle.kts
@@ -3,6 +3,7 @@ val kryptoVersion: String by project
 plugins {
     kotlin("multiplatform")
     id("com.android.library")
+    id("io.github.ttypic.swiftklib") version "0.1.0"
 }
 
 kotlin {
@@ -14,8 +15,12 @@ kotlin {
         iosArm64(),
         iosSimulatorArm64()
     ).forEach {
-        it.binaries.framework {
-            baseName = "shared"
+        it.compilations {
+            val main by getting {
+                cinterops {
+                    create("Attributes")
+                }
+            }
         }
     }
 
@@ -61,4 +66,11 @@ android {
         targetSdk = 32
     }
     namespace = "io.github.landrynorris.encryption"
+}
+
+swiftklib {
+    create("Attributes") {
+        path = file("src/swift")
+        packageName("io.github.landrynorris.encryption.swift")
+    }
 }

--- a/encryption/src/swift/Attributes.swift
+++ b/encryption/src/swift/Attributes.swift
@@ -1,0 +1,31 @@
+import Foundation
+import Security
+
+@objc public class Attributes: NSObject {
+    @objc public class func test() -> Int {
+        return 12
+    }
+
+    @objc public class func keyAttributes(_ access: SecAccessControl, tag: String) -> CFDictionary {
+        return [
+            kSecAttrKeyType as String           : kSecAttrKeyTypeEC,
+            kSecAttrKeySizeInBits as String     : 256,
+            kSecAttrTokenID as String           : kSecAttrTokenIDSecureEnclave,
+            kSecPrivateKeyAttrs as String : [
+                kSecAttrIsPermanent as String       : true,
+                kSecAttrApplicationTag as String    : tag,
+                kSecAttrAccessControl as String     : access
+            ]
+        ] as CFDictionary
+    }
+
+    @objc public class func keyQuery(_ tag: String) -> CFDictionary {
+        return [
+            kSecClass as String                 : kSecClassKey,
+            kSecAttrApplicationTag as String    : tag,
+            kSecAttrKeyType as String           : kSecAttrKeyTypeEC,
+            kSecMatchLimit as String            : kSecMatchLimitOne,
+            kSecReturnRef as String             : true
+        ] as CFDictionary
+    }
+}

--- a/mobileapp/build.gradle.kts
+++ b/mobileapp/build.gradle.kts
@@ -1,10 +1,8 @@
 import org.jetbrains.compose.ExperimentalComposeLibrary
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
 import org.jetbrains.kotlin.gradle.plugin.mpp.BitcodeEmbeddingMode
-import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeCompilation
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 import org.jetbrains.kotlin.gradle.plugin.mpp.TestExecutable
-import java.io.File
 import java.util.*
 
 val keystoreProperties =

--- a/mobileapp/src/commonMain/kotlin/io/github/landrynorris/multifactor/compose/CreateOtpDialog.kt
+++ b/mobileapp/src/commonMain/kotlin/io/github/landrynorris/multifactor/compose/CreateOtpDialog.kt
@@ -7,7 +7,7 @@ import io.github.landrynorris.multifactor.components.CreateOtpLogic
 import io.github.landrynorris.multifactor.platform.Dialog
 
 @Composable
-fun CreateOtpDialog(logic: CreateOtpLogic, onDismiss: () -> Unit) {
+internal fun CreateOtpDialog(logic: CreateOtpLogic, onDismiss: () -> Unit) {
     val state by logic.state.collectAsState()
     Dialog(onDismissRequest = onDismiss) {
         CreateOtpItem(state, onNameChanged = logic::nameChanged,

--- a/mobileapp/src/commonMain/kotlin/io/github/landrynorris/multifactor/compose/SwipeToDelete.kt
+++ b/mobileapp/src/commonMain/kotlin/io/github/landrynorris/multifactor/compose/SwipeToDelete.kt
@@ -22,7 +22,7 @@ import androidx.compose.ui.unit.dp
 
 @OptIn(ExperimentalMaterialApi::class, ExperimentalFoundationApi::class)
 @Composable
-fun LazyItemScope.SwipeToDelete(onDelete: () -> Unit, content: @Composable () -> Unit) {
+internal fun LazyItemScope.SwipeToDelete(onDelete: () -> Unit, content: @Composable () -> Unit) {
     val state = rememberDismissState(confirmStateChange = {
         if(it == DismissValue.DismissedToStart) {
             onDelete()
@@ -38,7 +38,7 @@ fun LazyItemScope.SwipeToDelete(onDelete: () -> Unit, content: @Composable () ->
 
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
-fun SwipeBackground(state: DismissState) {
+internal fun SwipeBackground(state: DismissState) {
     val direction = state.dismissDirection ?: return
     val color by animateColorAsState(
         when (state.targetValue) {

--- a/mobileapp/src/iosMain/kotlin/io/github/landrynorris/multifactor/platform/Initialize.ios.kt
+++ b/mobileapp/src/iosMain/kotlin/io/github/landrynorris/multifactor/platform/Initialize.ios.kt
@@ -1,25 +1,24 @@
 package io.github.landrynorris.multifactor.platform
 
-import com.russhwolf.settings.AppleSettings
 import com.russhwolf.settings.ExperimentalSettingsApi
-import com.russhwolf.settings.coroutines.FlowSettings
+import com.russhwolf.settings.NSUserDefaultsSettings
+import com.russhwolf.settings.coroutines.SuspendSettings
 import com.russhwolf.settings.coroutines.toFlowSettings
 import com.squareup.sqldelight.drivers.native.NativeSqliteDriver
 import io.github.landrynorris.database.AppDatabase
 import io.github.landrynorris.multifactor.repository.SettingsRepository
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.koin.dsl.module
 import platform.Foundation.NSUserDefaults
 
-@OptIn(ExperimentalSettingsApi::class, ExperimentalCoroutinesApi::class)
+@OptIn(ExperimentalSettingsApi::class)
 actual val platformModule = module {
     single {
         val driver = NativeSqliteDriver(AppDatabase.Schema, "otpdatabase")
         AppDatabase(driver)
     }
 
-    single {
-        AppleSettings(NSUserDefaults()).toFlowSettings()
+    single<SuspendSettings> {
+        NSUserDefaultsSettings(NSUserDefaults()).toFlowSettings()
     }
 
     single {

--- a/mobileapp/src/nativeInterop/cinterop/secure.def
+++ b/mobileapp/src/nativeInterop/cinterop/secure.def
@@ -5,7 +5,3 @@ package=secure
 
 #import <Foundation/Foundation.h>
 
-@interface Extensions: NSObject {}
-+ (CFDataRef) toCFData:(NSData*) data;
-@end
-


### PR DESCRIPTION
The SecKey library takes parameters as a CFDictionary. When I put an object in this dictionary from Kotlin, it adds the ObjHeader, which confuses the library. We should create the CFDictionary in Swift and return the result to Kotlin code.