### PR TITLE
upgrade github actions runner to java 17

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: 17
       - name: Run Tests
         run: bash ./gradlew test --stacktrace
   apk:


### PR DESCRIPTION
The new AGP versions require 17