### PR TITLE
Fix sync failing on non-Mac host

### DIFF
--- a/encryption/build.gradle.kts
+++ b/encryption/build.gradle.kts
@@ -1,9 +1,11 @@
+import org.jetbrains.kotlin.konan.target.HostManager
+
 val kryptoVersion: String by project
 
 plugins {
     kotlin("multiplatform")
     id("com.android.library")
-    id("io.github.ttypic.swiftklib") version "0.4.0"
+    id("io.github.ttypic.swiftklib") version "0.6.4"
 }
 
 kotlin {
@@ -16,9 +18,11 @@ kotlin {
         iosSimulatorArm64()
     ).forEach {
         it.compilations {
-            val main by getting {
-                cinterops {
-                    create("Attributes")
+            if(HostManager.hostIsMac) {
+                val main by getting {
+                    cinterops {
+                        create("Attributes")
+                    }
                 }
             }
         }


### PR DESCRIPTION
Previously, `swift-klib-plugin` would always register a task to create cinterops. Since Linux doesn't  have `xcrun`, the task would fail. The latest version of the plugin skips this on non-mac hosts.